### PR TITLE
Updated functional component check to simply check for createElement

### DIFF
--- a/projects/ngx-react-connector/package.json
+++ b/projects/ngx-react-connector/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@imaginelearning/ngx-react-connector",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"author": "Héctor Reyes López",
 	"license": "MIT",
 	"description": "This library is a connector that allows React components to be used in Angular applications easily.",

--- a/projects/ngx-react-connector/src/lib/react-connector/react-connector.directive.ts
+++ b/projects/ngx-react-connector/src/lib/react-connector/react-connector.directive.ts
@@ -43,7 +43,8 @@ export class ReactConnectorDirective implements OnInit, OnChanges {
 
 	isFunctionComponent(component): boolean {
 		const componentString = String(component);
-		return (typeof component === 'function' && !!componentString.match(/React([^\.]+)?\.createElement/ig));
+		// return (typeof component === 'function' && !!componentString.match(/React([^\.]+)?\.createElement/ig));
+		return (typeof component === 'function' && !!componentString.match(/.createElement/ig));
 	}
 
 	isReactComponent(component): boolean {


### PR DESCRIPTION
When bundled via WebPack, functional components are transpiled to use a renamed React instance. EX: _React.createElement_ is replaced with _react_WEBPACK_IMPORTED_MODULE_0___default.a_._createElement_. Conditions for a functional React component have been simplified to a function which contains a call to _.createElement_.

**After merging, this package needs to be manually published to MyGet and GitHub package registries.**